### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,7 +1,9 @@
 name: Pylint
 
-on: [push]
+permissions:
+  contents: read
 
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/xsser/security/code-scanning/45](https://github.com/deadjdona/xsser/security/code-scanning/45)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs linting and does not require write access, we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
